### PR TITLE
fix: Pass YouTube URL as FileData to Gemini

### DIFF
--- a/src/youtube_notion/writers/gemini_summary_writer.py
+++ b/src/youtube_notion/writers/gemini_summary_writer.py
@@ -200,17 +200,18 @@ class GeminiSummaryWriter(SummaryWriter):
             # Initialize Gemini client
             client = genai.Client(api_key=self.api_key)
             
-            # Prepare content for the API call - pass YouTube URL directly as text
-            # The newer Gemini models can process YouTube URLs when provided as text
-            full_prompt = f"""Please analyze this YouTube video: {video_url}
-
-{prompt}"""
-            
+            # Prepare content for the API call
             contents = [
                 types.Content(
                     role="user",
                     parts=[
-                        types.Part.from_text(text=full_prompt)
+                        types.Part(
+                            file_data=types.FileData(
+                                file_uri=video_url,
+                                mime_type="video/*"
+                            )
+                        ),
+                        types.Part.from_text(text=prompt)
                     ]
                 )
             ]


### PR DESCRIPTION
The previous implementation passed the YouTube URL as part of the text prompt to the Gemini API. This is not the recommended way to handle video inputs.

This change refactors the `_call_gemini_api` method in `GeminiSummaryWriter` to use `types.Part(file_data=...)` for the video URL. This aligns with the modern and correct approach for handling video URLs with the Gemini API, as specified in the Gemini documentation.

This change improves the reliability of video processing and ensures that the application uses the Gemini API as intended.